### PR TITLE
fix: check if folder exists

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -122,6 +122,9 @@ if __name__ == '__main__':
     with open(os.path.join(SAVE_PATH, f"benchmark_results.pkl"), "wb") as f:
         pkl.dump(outputs, f)
 
+    if not os.path.exists("logs"):
+        os.mkdir("logs")
+
     with open("logs/performance.csv", "a") as wf:
         for row in outputs:
             wf.write(f"{args.dataset},{args.detectLLM},{args.base_model_name},{row['name']},{json.dumps(row['general'])}\n")


### PR DESCRIPTION
After running an experiment, if there's no such path named `logs/`, the code raises an error. 

`FileNotFoundError: [Errno 2] No such file or directory: 'logs/performance.csv'`

Thus, results cannot be written into the .csv file. This small PR fixes the issue.