### PR TITLE
fix: load state_dict of conda

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,60 +1,72 @@
 import argparse
 import datetime
-import os
 import json
+import os
+
 import dataset_loader
-from methods.utils import load_base_model, load_base_model_and_tokenizer, filter_test_data, sample_dataset
-from methods.supervised import run_supervised_experiment
 from methods.detectgpt import run_perturbation_experiments
 from methods.gptzero import run_gptzero_experiment
-from methods.metric_based import get_ll, get_rank, get_entropy, get_rank_GLTR, run_threshold_experiment, run_GLTR_experiment
+from methods.metric_based import (
+    get_entropy,
+    get_ll,
+    get_rank,
+    get_rank_GLTR,
+    run_GLTR_experiment,
+    run_threshold_experiment,
+)
+from methods.supervised import run_supervised_experiment
+from methods.utils import (
+    filter_test_data,
+    load_base_model,
+    load_base_model_and_tokenizer,
+    sample_dataset,
+)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset', type=str, default="Essay")
-    parser.add_argument('--detectLLM', type=str, default="ChatGPT")
-    parser.add_argument('--method', type=str, default="Log-Likelihood")
-    parser.add_argument('--batch_size', type=int, default=16)
-    parser.add_argument('--base_model_name', type=str, default="gpt2-medium")
-    parser.add_argument('--mask_filling_model_name',
-                        type=str, default="t5-base")
-    parser.add_argument('--cache_dir', type=str, default=".cache")
-    parser.add_argument('--DEVICE', type=str, default="cuda")
+    parser.add_argument("--dataset", type=str, default="Essay")
+    parser.add_argument("--detectLLM", type=str, default="ChatGPT")
+    parser.add_argument("--method", type=str, default="Log-Likelihood")
+    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--base_model_name", type=str, default="gpt2-medium")
+    parser.add_argument("--mask_filling_model_name", type=str, default="t5-base")
+    parser.add_argument("--cache_dir", type=str, default=".cache")
+    parser.add_argument("--DEVICE", type=str, default="cuda")
 
     # params for DetectGPT
-    parser.add_argument('--pct_words_masked', type=float, default=0.3)
-    parser.add_argument('--span_length', type=int, default=2)
-    parser.add_argument('--n_perturbation_list', type=str, default="10")
-    parser.add_argument('--n_perturbation_rounds', type=int, default=1)
-    parser.add_argument('--chunk_size', type=int, default=20)
-    parser.add_argument('--n_similarity_samples', type=int, default=20)
-    parser.add_argument('--int8', action='store_true')
-    parser.add_argument('--half', action='store_true')
-    parser.add_argument('--do_top_k', action='store_true')
-    parser.add_argument('--top_k', type=int, default=40)
-    parser.add_argument('--do_top_p', action='store_true')
-    parser.add_argument('--top_p', type=float, default=0.96)
-    parser.add_argument('--buffer_size', type=int, default=1)
-    parser.add_argument('--mask_top_p', type=float, default=1.0)
-    parser.add_argument('--random_fills', action='store_true')
-    parser.add_argument('--random_fills_tokens', action='store_true')
+    parser.add_argument("--pct_words_masked", type=float, default=0.3)
+    parser.add_argument("--span_length", type=int, default=2)
+    parser.add_argument("--n_perturbation_list", type=str, default="10")
+    parser.add_argument("--n_perturbation_rounds", type=int, default=1)
+    parser.add_argument("--chunk_size", type=int, default=20)
+    parser.add_argument("--n_similarity_samples", type=int, default=20)
+    parser.add_argument("--int8", action="store_true")
+    parser.add_argument("--half", action="store_true")
+    parser.add_argument("--do_top_k", action="store_true")
+    parser.add_argument("--top_k", type=int, default=40)
+    parser.add_argument("--do_top_p", action="store_true")
+    parser.add_argument("--top_p", type=float, default=0.96)
+    parser.add_argument("--buffer_size", type=int, default=1)
+    parser.add_argument("--mask_top_p", type=float, default=1.0)
+    parser.add_argument("--random_fills", action="store_true")
+    parser.add_argument("--random_fills_tokens", action="store_true")
 
     # params for GPTZero
-    parser.add_argument('--gptzero_key', type=str, default="")
+    parser.add_argument("--gptzero_key", type=str, default="")
 
     args = parser.parse_args()
 
     DEVICE = args.DEVICE
 
-    START_DATE = datetime.datetime.now().strftime('%Y-%m-%d')
-    START_TIME = datetime.datetime.now().strftime('%H-%M-%S-%f')
+    START_DATE = datetime.datetime.now().strftime("%Y-%m-%d")
+    START_TIME = datetime.datetime.now().strftime("%H-%M-%S-%f")
 
-    print(f'Loading dataset {args.dataset}...')
+    print(f"Loading dataset {args.dataset}...")
     data = dataset_loader.load(args.dataset, detectLLM=args.detectLLM)
     # data = sample_dataset(data, 50, 10)
     # data = filter_test_data(data, max_length=25)
 
-    base_model_name = args.base_model_name.replace('/', '_')
+    base_model_name = args.base_model_name.replace("/", "_")
     SAVE_PATH = f"update_results/{base_model_name}-{args.mask_filling_model_name}/{args.dataset}-{args.detectLLM}"
     if not os.path.exists(SAVE_PATH):
         os.makedirs(SAVE_PATH)
@@ -77,26 +89,27 @@ if __name__ == '__main__':
 
     # get generative model
     base_model, base_tokenizer = load_base_model_and_tokenizer(
-        args.base_model_name, cache_dir)
+        args.base_model_name, cache_dir
+    )
     load_base_model(base_model, DEVICE)
 
     # def phd_criterion(text): return get_phd(
     #     text, base_model, base_tokenizer, DEVICE)
 
-    def ll_criterion(text): return get_ll(
-        text, base_model, base_tokenizer, DEVICE)
+    def ll_criterion(text):
+        return get_ll(text, base_model, base_tokenizer, DEVICE)
 
-    def rank_criterion(text): return -get_rank(text,
-                                               base_model, base_tokenizer, DEVICE, log=False)
+    def rank_criterion(text):
+        return -get_rank(text, base_model, base_tokenizer, DEVICE, log=False)
 
-    def logrank_criterion(text): return -get_rank(text,
-                                                  base_model, base_tokenizer, DEVICE, log=True)
+    def logrank_criterion(text):
+        return -get_rank(text, base_model, base_tokenizer, DEVICE, log=True)
 
-    def entropy_criterion(text): return get_entropy(
-        text, base_model, base_tokenizer, DEVICE)
+    def entropy_criterion(text):
+        return get_entropy(text, base_model, base_tokenizer, DEVICE)
 
-    def GLTR_criterion(text): return get_rank_GLTR(
-        text, base_model, base_tokenizer, DEVICE)
+    def GLTR_criterion(text):
+        return get_rank_GLTR(text, base_model, base_tokenizer, DEVICE)
 
     outputs = []
     # outputs.append(run_threshold_experiment(data, phd_criterion, "phd"))
@@ -104,16 +117,13 @@ if __name__ == '__main__':
     # method_list = ["Log-Likelihood", "Rank", "Log-Rank", "Entropy", "GLTR", "OpenAI-D", "ConDA", "ChatGPT-D", "LM-D", "DetectGPT", "LRR", "NPR", "GPTZero"]
 
     if args.method == "Log-Likelihood":
-        outputs.append(run_threshold_experiment(
-            data, ll_criterion, "likelihood"))
+        outputs.append(run_threshold_experiment(data, ll_criterion, "likelihood"))
     elif args.method == "Rank":
         outputs.append(run_threshold_experiment(data, rank_criterion, "rank"))
     elif args.method == "Log-Rank":
-        outputs.append(run_threshold_experiment(
-            data, logrank_criterion, "log_rank"))
+        outputs.append(run_threshold_experiment(data, logrank_criterion, "log_rank"))
     elif args.method == "Entropy":
-        outputs.append(run_threshold_experiment(
-            data, entropy_criterion, "entropy"))
+        outputs.append(run_threshold_experiment(data, entropy_criterion, "entropy"))
     elif args.method == "GLTR":
         outputs.append(run_GLTR_experiment(data, GLTR_criterion, "rank_GLTR"))
 
@@ -132,44 +142,58 @@ if __name__ == '__main__':
         outputs.append(
             run_supervised_experiment(
                 data,
-                model='roberta-base-openai-detector',
+                model="roberta-base-openai-detector",
                 cache_dir=cache_dir,
                 batch_size=batch_size,
-                DEVICE=DEVICE))
+                DEVICE=DEVICE,
+            )
+        )
     elif args.method == "ConDA":
         outputs.append(
             run_supervised_experiment(
                 data,
-                model='update_results/ConDA',
+                model="roberta-base",
                 cache_dir=cache_dir,
                 batch_size=batch_size,
-                DEVICE=DEVICE))
+                pos_bit=1,
+                DEVICE=DEVICE,
+                finetune=True,
+                state_dict_path="update_results/ConDA/fair_wmt19_chatgpt_syn_rep_loss1.pt",
+                state_dict_key="model_state_dict",
+            )
+        )
     elif args.method == "ChatGPT-D":
         outputs.append(
             run_supervised_experiment(
                 data,
-                model='Hello-SimpleAI/chatgpt-detector-roberta',
+                model="Hello-SimpleAI/chatgpt-detector-roberta",
                 cache_dir=cache_dir,
                 batch_size=batch_size,
                 DEVICE=DEVICE,
-                pos_bit=1))
+                pos_bit=1,
+            )
+        )
     elif args.method == "LM-D":
         outputs.append(
             run_supervised_experiment(
                 data,
-                model='distilbert-base-uncased',
+                model="distilbert-base-uncased",
                 cache_dir=cache_dir,
                 batch_size=batch_size,
                 DEVICE=DEVICE,
                 pos_bit=1,
                 finetune=True,
-                save_path=SAVE_PATH +
-                f"/LM-D"))
+                save_path=SAVE_PATH + f"/LM-D",
+            )
+        )
 
     # run LRR
     elif args.method == "LRR":
-        outputs.append(run_perturbation_experiments(
-            args, data, base_model, base_tokenizer, method="LRR"))
+        outputs.append(
+            run_perturbation_experiments(
+                args, data, base_model, base_tokenizer, method="LRR"
+            )
+        )
 
     # # run GPTZero: pleaze specify your gptzero_key in the args
     elif args.method == "GPTZero":
@@ -177,17 +201,26 @@ if __name__ == '__main__':
 
     # run DetectGPT
     elif args.method == "DetectGPT":
-        outputs.append(run_perturbation_experiments(
-            args, data, base_model, base_tokenizer, method="DetectGPT"))
+        outputs.append(
+            run_perturbation_experiments(
+                args, data, base_model, base_tokenizer, method="DetectGPT"
+            )
+        )
 
     # run NPR
     elif args.method == "NPR":
-        outputs.append(run_perturbation_experiments(
-            args, data, base_model, base_tokenizer, method="NPR"))
+        outputs.append(
+            run_perturbation_experiments(
+                args, data, base_model, base_tokenizer, method="NPR"
+            )
+        )
 
     # save results
     import pickle as pkl
-    with open(os.path.join(SAVE_PATH, f"{args.method}_benchmark_results.pkl"), "wb") as f:
+
+    with open(
+        os.path.join(SAVE_PATH, f"{args.method}_benchmark_results.pkl"), "wb"
+    ) as f:
         pkl.dump(outputs, f)
 
     if not os.path.exists("logs/"):
@@ -195,6 +228,7 @@ if __name__ == '__main__':
     with open("logs/performance.csv", "a") as wf:
         for row in outputs:
             wf.write(
-                f"{args.dataset},{args.detectLLM},{args.base_model_name},{args.method},{json.dumps(row['general'])}\n")
+                f"{args.dataset},{args.detectLLM},{args.base_model_name},{args.method},{json.dumps(row['general'])}\n"
+            )
 
     print("Finish")

--- a/methods/supervised.py
+++ b/methods/supervised.py
@@ -1,10 +1,11 @@
 import numpy as np
-import transformers
 import torch
-from tqdm import tqdm
-from methods.utils import timeit, cal_metrics
+import transformers
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 from transformers import AdamW
+
+from methods.utils import cal_metrics, timeit
 
 
 class CustomDataset(torch.utils.data.Dataset):
@@ -13,9 +14,8 @@ class CustomDataset(torch.utils.data.Dataset):
         self.labels = labels
 
     def __getitem__(self, idx):
-        item = {key: torch.tensor(val[idx])
-                for key, val in self.encodings.items()}
-        item['labels'] = torch.tensor(self.labels[idx])
+        item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
+        item["labels"] = torch.tensor(self.labels[idx])
         return item
 
     def __len__(self):
@@ -24,61 +24,72 @@ class CustomDataset(torch.utils.data.Dataset):
 
 @timeit
 def run_supervised_experiment(
-        data,
-        model,
-        cache_dir,
-        batch_size,
-        DEVICE,
-        pos_bit=0,
-        finetune=False,
-        num_labels=2,
-        epochs=3,
-        save_path=None,
-        **kwargs):
-    print(f'Beginning supervised evaluation with {model}...')
+    data,
+    model,
+    cache_dir,
+    batch_size,
+    DEVICE,
+    pos_bit=0,
+    finetune=False,
+    num_labels=2,
+    epochs=3,
+    save_path=None,
+    **kwargs,
+):
+    print(f"Beginning supervised evaluation with {model}...")
     detector = transformers.AutoModelForSequenceClassification.from_pretrained(
-        model,
-        num_labels=num_labels,
-        cache_dir=cache_dir,
-        ignore_mismatched_sizes=True).to(DEVICE)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(
-        model, cache_dir=cache_dir)
+        model, num_labels=num_labels, cache_dir=cache_dir, ignore_mismatched_sizes=True
+    ).to(DEVICE)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model, cache_dir=cache_dir)
 
     if ("state_dict_path" in kwargs) and ("state_dict_key" in kwargs):
         detector.load_state_dict(
-            torch.load(
-                kwargs["state_dict_path"],
-                map_location='cpu')[
-                kwargs["state_dict_key"]])
+            torch.load(kwargs["state_dict_path"], map_location="cpu")[
+                kwargs["state_dict_key"]
+            ],
+            strict=False,
+        )
 
     if finetune:
-        fine_tune_model(detector, tokenizer, data, batch_size,
-                        DEVICE, pos_bit, num_labels, epochs=epochs)
+        fine_tune_model(
+            detector,
+            tokenizer,
+            data,
+            batch_size,
+            DEVICE,
+            pos_bit,
+            num_labels,
+            epochs=epochs,
+        )
         if save_path:
             detector.save_pretrained(save_path)
             tokenizer.save_pretrained(save_path)
 
-    train_text = data['train']['text']
-    train_label = data['train']['label']
-    test_text = data['test']['text']
-    test_label = data['test']['label']
+    train_text = data["train"]["text"]
+    train_label = data["train"]["label"]
+    test_text = data["test"]["text"]
+    test_label = data["test"]["label"]
 
     # detector.save_pretrained(".cache/lm-d-xxx", from_pt=True)
 
     if num_labels == 2:
         train_preds = get_supervised_model_prediction(
-            detector, tokenizer, train_text, batch_size, DEVICE, pos_bit)
+            detector, tokenizer, train_text, batch_size, DEVICE, pos_bit
+        )
         test_preds = get_supervised_model_prediction(
-            detector, tokenizer, test_text, batch_size, DEVICE, pos_bit)
+            detector, tokenizer, test_text, batch_size, DEVICE, pos_bit
+        )
     else:
         train_preds = get_supervised_model_prediction_multi_classes(
-            detector, tokenizer, train_text, batch_size, DEVICE, pos_bit)
+            detector, tokenizer, train_text, batch_size, DEVICE, pos_bit
+        )
         test_preds = get_supervised_model_prediction_multi_classes(
-            detector, tokenizer, test_text, batch_size, DEVICE, pos_bit)
+            detector, tokenizer, test_text, batch_size, DEVICE, pos_bit
+        )
 
     predictions = {
-        'train': train_preds,
-        'test': test_preds,
+        "train": train_preds,
+        "test": test_preds,
     }
     y_train_pred_prob = train_preds
     y_train_pred = [round(_) for _ in y_train_pred_prob]
@@ -92,90 +103,96 @@ def run_supervised_experiment(
     test_res = cal_metrics(y_test, y_test_pred, y_test_pred_prob)
     acc_train, precision_train, recall_train, f1_train, auc_train = train_res
     acc_test, precision_test, recall_test, f1_test, auc_test = test_res
-    print(f"{model} acc_train: {acc_train}, precision_train: {precision_train}, recall_train: {recall_train}, f1_train: {f1_train}, auc_train: {auc_train}")
-    print(f"{model} acc_test: {acc_test}, precision_test: {precision_test}, recall_test: {recall_test}, f1_test: {f1_test}, auc_test: {auc_test}")
+    print(
+        f"{model} acc_train: {acc_train}, precision_train: {precision_train}, recall_train: {recall_train}, f1_train: {f1_train}, auc_train: {auc_train}"
+    )
+    print(
+        f"{model} acc_test: {acc_test}, precision_test: {precision_test}, recall_test: {recall_test}, f1_test: {f1_test}, auc_test: {auc_test}"
+    )
 
     # free GPU memory
     del detector
     torch.cuda.empty_cache()
 
     return {
-        'name': model,
-        'predictions': predictions,
-        'general': {
-            'acc_train': acc_train,
-            'precision_train': precision_train,
-            'recall_train': recall_train,
-            'f1_train': f1_train,
-            'auc_train': auc_train,
-            'acc_test': acc_test,
-            'precision_test': precision_test,
-            'recall_test': recall_test,
-            'f1_test': f1_test,
-            'auc_test': auc_test,
-        }
+        "name": model,
+        "predictions": predictions,
+        "general": {
+            "acc_train": acc_train,
+            "precision_train": precision_train,
+            "recall_train": recall_train,
+            "f1_train": f1_train,
+            "auc_train": auc_train,
+            "acc_test": acc_test,
+            "precision_test": precision_test,
+            "recall_test": recall_test,
+            "f1_test": f1_test,
+            "auc_test": auc_test,
+        },
     }
 
 
 def run_supervised_experiment_multi_test_length(
-        data,
-        model,
-        cache_dir,
-        batch_size,
-        DEVICE,
-        pos_bit=0,
-        finetune=False,
-        num_labels=2,
-        epochs=3,
-        save_path=None,
-        lengths=[
-            10,
-            20,
-            50,
-            100,
-            200,
-            500,
-            -1],
-        **kwargs):
-    print(f'Beginning supervised evaluation with {model}...')
+    data,
+    model,
+    cache_dir,
+    batch_size,
+    DEVICE,
+    pos_bit=0,
+    finetune=False,
+    num_labels=2,
+    epochs=3,
+    save_path=None,
+    lengths=[10, 20, 50, 100, 200, 500, -1],
+    **kwargs,
+):
+    print(f"Beginning supervised evaluation with {model}...")
     detector = transformers.AutoModelForSequenceClassification.from_pretrained(
-        model,
-        num_labels=num_labels,
-        cache_dir=cache_dir,
-        ignore_mismatched_sizes=True).to(DEVICE)
-    tokenizer = transformers.AutoTokenizer.from_pretrained(
-        model, cache_dir=cache_dir)
+        model, num_labels=num_labels, cache_dir=cache_dir, ignore_mismatched_sizes=True
+    ).to(DEVICE)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model, cache_dir=cache_dir)
 
     if ("state_dict_path" in kwargs) and ("state_dict_key" in kwargs):
         detector.load_state_dict(
-            torch.load(
-                kwargs["state_dict_path"],
-                map_location='cpu')[
-                kwargs["state_dict_key"]])
+            torch.load(kwargs["state_dict_path"], map_location="cpu")[
+                kwargs["state_dict_key"]
+            ]
+        )
 
     if finetune:
-        fine_tune_model(detector, tokenizer, data, batch_size,
-                        DEVICE, pos_bit, num_labels, epochs=epochs)
+        fine_tune_model(
+            detector,
+            tokenizer,
+            data,
+            batch_size,
+            DEVICE,
+            pos_bit,
+            num_labels,
+            epochs=epochs,
+        )
         if save_path:
             detector.save_pretrained(save_path)
             tokenizer.save_pretrained(save_path)
 
     res = {}
-    from methods.utils import cut_length, cal_metrics
+    from methods.utils import cal_metrics, cut_length
+
     for length in lengths:
-        test_text = data['test']['text']
+        test_text = data["test"]["text"]
         test_text = [cut_length(_, length) for _ in test_text]
-        test_label = data['test']['label']
+        test_label = data["test"]["label"]
 
         # detector.save_pretrained(".cache/lm-d-xxx", from_pt=True)
 
         if num_labels == 2:
 
             test_preds = get_supervised_model_prediction(
-                detector, tokenizer, test_text, batch_size, DEVICE, pos_bit)
+                detector, tokenizer, test_text, batch_size, DEVICE, pos_bit
+            )
         else:
             test_preds = get_supervised_model_prediction_multi_classes(
-                detector, tokenizer, test_text, batch_size, DEVICE, pos_bit)
+                detector, tokenizer, test_text, batch_size, DEVICE, pos_bit
+            )
 
         y_test_pred_prob = test_preds
         y_test_pred = [round(_) for _ in y_test_pred_prob]
@@ -184,7 +201,9 @@ def run_supervised_experiment_multi_test_length(
         test_res = cal_metrics(y_test, y_test_pred, y_test_pred_prob)
         acc_test, precision_test, recall_test, f1_test, auc_test = test_res
 
-        print(f"{model} {length} acc_test: {acc_test}, precision_test: {precision_test}, recall_test: {recall_test}, f1_test: {f1_test}, auc_test: {auc_test}")
+        print(
+            f"{model} {length} acc_test: {acc_test}, precision_test: {precision_test}, recall_test: {recall_test}, f1_test: {f1_test}, auc_test: {auc_test}"
+        )
         res[length] = test_res
     # free GPU memory
     del detector
@@ -193,12 +212,8 @@ def run_supervised_experiment_multi_test_length(
 
 
 def get_supervised_model_prediction(
-        model,
-        tokenizer,
-        data,
-        batch_size,
-        DEVICE,
-        pos_bit=0):
+    model, tokenizer, data, batch_size, DEVICE, pos_bit=0
+):
     with torch.no_grad():
         # get predictions for real
         preds = []
@@ -210,14 +225,15 @@ def get_supervised_model_prediction(
                 padding=True,
                 truncation=True,
                 max_length=512,
-                return_tensors="pt").to(DEVICE)
-            preds.extend(model(**batch_data).logits.softmax(-1)
-                         [:, pos_bit].tolist())
+                return_tensors="pt",
+            ).to(DEVICE)
+            preds.extend(model(**batch_data).logits.softmax(-1)[:, pos_bit].tolist())
     return preds
 
 
 def get_supervised_model_prediction_multi_classes(
-        model, tokenizer, data, batch_size, DEVICE, pos_bit=0):
+    model, tokenizer, data, batch_size, DEVICE, pos_bit=0
+):
     with torch.no_grad():
         # get predictions for real
         preds = []
@@ -229,28 +245,22 @@ def get_supervised_model_prediction_multi_classes(
                 padding=True,
                 truncation=True,
                 max_length=512,
-                return_tensors="pt").to(DEVICE)
-            preds.extend(torch.argmax(
-                model(**batch_data).logits, dim=1).tolist())
+                return_tensors="pt",
+            ).to(DEVICE)
+            preds.extend(torch.argmax(model(**batch_data).logits, dim=1).tolist())
     return preds
 
 
 def fine_tune_model(
-        model,
-        tokenizer,
-        data,
-        batch_size,
-        DEVICE,
-        pos_bit=1,
-        num_labels=2,
-        epochs=3):
+    model, tokenizer, data, batch_size, DEVICE, pos_bit=1, num_labels=2, epochs=3
+):
 
     # https://huggingface.co/transformers/v3.2.0/custom_datasets.html
 
-    train_text = data['train']['text']
-    train_label = data['train']['label']
-    test_text = data['test']['text']
-    test_label = data['test']['label']
+    train_text = data["train"]["text"]
+    train_label = data["train"]["label"]
+    test_text = data["test"]["text"]
+    test_label = data["test"]["label"]
 
     if pos_bit == 0 and num_labels == 2:
         train_label = [1 if _ == 0 else 0 for _ in train_label]
@@ -263,26 +273,36 @@ def fine_tune_model(
 
     model.train()
 
-    train_loader = DataLoader(
-        train_dataset, batch_size=batch_size, shuffle=True)
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
 
-    no_decay = ['bias', 'LayerNorm.weight']
+    no_decay = ["bias", "LayerNorm.weight"]
     optimizer_grouped_parameters = [
-        {'params': [p for n, p in model.named_parameters() if not any(
-            nd in n for nd in no_decay)], 'weight_decay': 0.01},
-        {'params': [p for n, p in model.named_parameters() if any(
-            nd in n for nd in no_decay)], 'weight_decay': 0.0}
+        {
+            "params": [
+                p
+                for n, p in model.named_parameters()
+                if not any(nd in n for nd in no_decay)
+            ],
+            "weight_decay": 0.01,
+        },
+        {
+            "params": [
+                p
+                for n, p in model.named_parameters()
+                if any(nd in n for nd in no_decay)
+            ],
+            "weight_decay": 0.0,
+        },
     ]
     optimizer = AdamW(optimizer_grouped_parameters, lr=1e-5)
 
     for epoch in range(epochs):
         for batch in tqdm(train_loader, desc=f"Fine-tuning: {epoch} epoch"):
             optimizer.zero_grad()
-            input_ids = batch['input_ids'].to(DEVICE)
-            attention_mask = batch['attention_mask'].to(DEVICE)
-            labels = batch['labels'].to(DEVICE)
-            outputs = model(
-                input_ids, attention_mask=attention_mask, labels=labels)
+            input_ids = batch["input_ids"].to(DEVICE)
+            attention_mask = batch["attention_mask"].to(DEVICE)
+            labels = batch["labels"].to(DEVICE)
+            outputs = model(input_ids, attention_mask=attention_mask, labels=labels)
             loss = outputs[0]
             loss.backward()
             optimizer.step()


### PR DESCRIPTION
Normally, to run ConDA experiments, there's a need for preprocessing. 

The pull request covers that preprocessing part and allows user to run ConDA experiments in a smooth way. Now, Locating the downloaded pre-trained weight file namely `fair_wmt19_chatgpt_syn_rep_loss1.pt` under directory `update_results/ConDA` is sufficient. Also, files are refactored using `black`. 

Added following parameter to the process of restoring the `model_state_dict`
```python
strict=False
``` 
otherwise user would face the following error: `Unexpected key(s) in state_dict: "roberta.embeddings.position_ids".` 

This PR resolves issue #4.